### PR TITLE
fixed value error due to mdmc_reduce

### DIFF
--- a/unet_lightning.py
+++ b/unet_lightning.py
@@ -35,18 +35,21 @@ class Segmentation_UNET(pl.LightningModule):
                 metric_name="F1",
                 num_classes=self.num_classes,
                 average="none",
+                mdmc_average='samplewise',
             )
             self.f1_valid = CustomMetric(
                 metric=torchmetrics.functional.f1,
                 metric_name="F1",
                 num_classes=self.num_classes,
                 average="none",
+                mdmc_average='samplewise',
             )
             self.f1_test = CustomMetric(
                 metric=torchmetrics.functional.f1,
                 metric_name="F1",
                 num_classes=self.num_classes,
                 average="none",
+                mdmc_average='samplewise',
             )
 
             self.iou_train = CustomMetric(


### PR DESCRIPTION
`torchmetrics.functional.f1` calls `torchmetrics.functional.fbeta` which in-turn calls `torchmetrics.functional.stat_score` and it raises value error if inputs are multi-dimensional multi-class and `mdmc_reduce` is not provided. Added `mdmc_average` parameter while defining an instance of the class CustomMetric and it's value could be either `samplewise` or `global`. This fixes #11.